### PR TITLE
Correcting Pages index and config information

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,9 +43,9 @@ navigation:
   internal: false
 
 repos:
-- name: 18F Agile Design Working Group
+- name: 18F Content Guild
   description: Main repository
-  url: https://github.com/18F/wg-agiledesign
+  url: https://github.com/18F/g-content
 
 back_link:
   url: "https://pages.18f.gov/"

--- a/index.md
+++ b/index.md
@@ -2,14 +2,20 @@
 title: Introduction
 ---
 
-## Who are we?
+## Who we are
 
-This is a placeholder site for now!
-
-## What do we do/what have we done?
+We promote concise, elegant, user-centered content. We plan for the creation, publication, and governance of useful, usable content.
 
 
+## What we've done, and what we're working on
 
-## Where are we/how can you reach us?
+- A thoughtful, accessible [content style guide](https://pages.18f.gov/content-guide/)
+- Clarification of 18F’s editorial goals and alignment with other digital services groups
+- A consistent “chain of custody” for how content moves through conception, ideation, development, publication, and governance across projects
+- A content framework for our delivery team
+
+
+
+## How you can reach us
 
 Our 18F Slack channel is #g-content.

--- a/index.md
+++ b/index.md
@@ -4,14 +4,12 @@ title: Introduction
 
 ## Who are we?
 
-We are a [guild](https://pages.18f.gov/grouplet-playbook/guilds/) dedicated to
-uncovering the nuts and bolts of planning, managing, executing and
-communicating design in an agile team.
+This is a placeholder site for now!
 
 ## What do we do/what have we done?
 
-We maintain the ...
+
 
 ## Where are we/how can you reach us?
 
-Our 18F Slack channel is #g-content. We hold regular meetings on...
+Our 18F Slack channel is #g-content.


### PR DESCRIPTION
Just minor edits to remove mentions of the agile design working group. I created this as a branch off of readme-updates instead of 18f-pages by mistake, but I figure that should work out fine. :)
