### PR TITLE
Upgrade yajl-ruby to 1.3.1 for security reasons.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     sass (3.4.19)
     toml (0.1.2)
       parslet (~> 1.5.0)
-    yajl-ruby (1.2.1)
+    yajl-ruby (1.3.1)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
It's not clear to me that there should be any ruby at all in this repository, but for the moment the quickest way to address https://nvd.nist.gov/vuln/detail/CVE-2017-16516 is to have `Gemfile.lock` refer to a later version of `yajl-ruby`.